### PR TITLE
fix plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.


### PR DESCRIPTION
since this pulls in hex, it breaks stuff across rebar3 versions.  we don't need this globally.